### PR TITLE
Rule creation bugfix

### DIFF
--- a/app/api/api_v1/endpoints/rule.py
+++ b/app/api/api_v1/endpoints/rule.py
@@ -68,10 +68,10 @@ def create_rule(
             )
 
     for cond in cond_times.values():
-        if len(cond) >= 2:
+        if len(cond) > 2:
             raise HTTPException(
                 status_code=400,
-                detail="Can't have more that one condition per unit."
+                detail="Can't have more that two condition per unit."
             )
 
     cr = CreateRule(name=rule.name, description=rule.description, from_time=rule.from_time, to_time=rule.to_time)


### PR DESCRIPTION
When creating a rule, you can have two conditions, but no more (temp == 10 is fine, temp < 20, temp > 10 is also fine)
temp > 20, temp > 30, temp < 50 is redundant